### PR TITLE
Feature/assignment3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *swp
 *swo
 db/store.sqlite3
+db/store_test.sqlite3

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Products App
+Simple app for online e-commerce tool. It adds only the Product functionality
+
+## Running it
+
+  . `bundle install`
+  . `./bin/migrate.rb`
+  . `./bin/store.rb`
+
+
+## Testing it
+  . `ruby -I test tests/product_test.rb`
+

--- a/db/migrate/20170915211905_add_input_and_output_vat_to_products.rb
+++ b/db/migrate/20170915211905_add_input_and_output_vat_to_products.rb
@@ -1,0 +1,11 @@
+class AddInputAndOutputVatToProducts < ActiveRecord::Migration[5.1]
+  def change
+    add_column :products, :input_vat,      :float, default: 0
+    add_column :products, :output_vat,     :float, default: 0
+    add_column :products, :price_with_vat, :float
+
+    # set the price_with_vat to the same value as the price while VAT isn't setup. batches of 1000
+    Product.find_each {|product| product.update output_vat: 0 }
+  end
+
+end

--- a/models/product.rb
+++ b/models/product.rb
@@ -12,6 +12,7 @@ class Product < ActiveRecord::Base
   validates_numericality_of :price,      greater_than_or_equal_to: 0
   validates_numericality_of :input_vat,  greater_than_or_equal_to: 0
   validates_numericality_of :output_vat, greater_than_or_equal_to: 0
+  validate :has_proper_vat
 
   ### Scopes
   scope :cheapest,                -> { order("price ASC" )         .limit(1).first }
@@ -104,6 +105,12 @@ class Product < ActiveRecord::Base
   protected
   def adjust_price_with_vat
     self.price_with_vat = ((1 + output_vat/100)*price - input_vat).round(2)
+  end
+
+  def has_proper_vat
+    if (self.output_vat / 100 * self.price - self.input_vat) < 0
+      errors.add(:output_vat, "Output VAT cannot produce a negative tax")
+    end
   end
 
 end

--- a/models/product.rb
+++ b/models/product.rb
@@ -1,16 +1,23 @@
 # Product class
 # Supports name and price fields
-# Print out the class name with name and price
-# Print out name and price separated
+# Prints out all the calculations
+# Also, supports VAT fixed input and percentange output
+#
 class Product < ActiveRecord::Base
   # fix it to support only $
   CURRENCY = '$'
 
+  ### Validations
   validates :name, presence: true
-  validates :price, presence: true
+  validates_numericality_of :price,      greater_than_or_equal_to: 0
+  validates_numericality_of :input_vat,  greater_than_or_equal_to: 0
+  validates_numericality_of :output_vat, greater_than_or_equal_to: 0
 
-  scope :cheapest,       -> { order("price ASC" ).limit(1).first }
-  scope :most_expensive, -> { order("price DESC").limit(1).first }
+  ### Scopes
+  scope :cheapest,                -> { order("price ASC" )         .limit(1).first }
+  scope :most_expensive,          -> { order("price DESC")         .limit(1).first }
+  scope :cheapest_with_vat,       -> { order("price_with_vat ASC" ).limit(1).first }
+  scope :most_expensive_with_vat, -> { order("price_with_vat DESC").limit(1).first }
 
   def to_s
     puts "Product NAME: #{name} PRICE: #{price_with_currency}"
@@ -22,10 +29,32 @@ class Product < ActiveRecord::Base
     "#{CURRENCY}#{price.to_f}"
   end
 
+  ### VAT: Adjust the price_with_vat everytime it's composition is changed
+  def price= price
+    super(price)
+    self.adjust_price_with_vat
+  end
+
+  def output_vat= vat
+    super(vat)
+    self.adjust_price_with_vat
+  end
+
+  def input_vat= vat
+    super(vat)
+    self.adjust_price_with_vat
+  end
+
   def self.prices_sum products = nil
     products ||= self.all
 
     products.pluck(:price).reduce(0, :+)
+  end
+
+  def self.prices_sum_with_vat products = nil
+    products ||= self.all
+
+    products.pluck(:price_with_vat).reduce(0, :+)
   end
 
   ### PRINTING METHODS
@@ -35,6 +64,10 @@ class Product < ActiveRecord::Base
 
   def print_price
     puts "Price: #{price_with_currency}"
+  end
+
+  def print_price_with_vat
+    puts "Price with VAT: #{price_with_currency(price_with_vat)}"
   end
 
   def self.print_products_sum products = nil
@@ -67,4 +100,10 @@ class Product < ActiveRecord::Base
   def self.print_most_expensive_product products = nil
     self.print_by_price_ordering :most_expensive
   end
+
+  protected
+  def adjust_price_with_vat
+    self.price_with_vat = ((1 + output_vat/100)*price - input_vat).round(2)
+  end
+
 end

--- a/tests/product_test.rb
+++ b/tests/product_test.rb
@@ -1,46 +1,68 @@
-require 'test/unit'
-require_relative '../config/environment'
+require_relative './test_helper'
 
 # Product class tests
 class ProductTest < Test::Unit::TestCase
 
   def setup
-    Product.destroy_all
+    setup_database
+    Product.create! [
+      {name: "banana", price: 45.11, output_vat: 10, input_vat: 2},
+      {name: "papaya", price: 10   , output_vat: 20, input_vat: 1},
+      {name: "apple",  price: 14.1 , output_vat: 1, input_vat: 10},
+      {name: "mango",  price: 20   , output_vat: 300,  input_vat: 2}
+    ]
   end
 
   test 'it should calc the sum of all products' do
-    Product.create [
-      {name: "banana", price: 45.11},
-      {name: "papaya", price: 10},
-      {name: "apple", price: 14.1},
-      {name: "mango", price: 20}
-    ]
-
     assert_equal 89.21, Product.prices_sum.to_f
     assert_equal 89.21, Product.prices_sum(Product.all).to_f
   end
 
   test 'it should get the cheapest product' do
-    Product.create [
-      {name: "banana", price: 45.11},
-      {name: "papaya", price: 10},
-      {name: "apple", price: 14.1},
-      {name: "mango", price: 20}
-    ]
-
     assert_equal "papaya", Product.cheapest.name
     assert_equal "papaya", Product.all.cheapest.name
   end
 
   test 'it should get the most expensive product' do
-    Product.create [
-      {name: "banana", price: 45.11},
-      {name: "papaya", price: 10},
-      {name: "apple", price: 14.1},
-      {name: "mango", price: 20}
-    ]
-
     assert_equal "banana", Product.most_expensive.name
     assert_equal "banana", Product.all.most_expensive.name
   end
+
+  ### VAT
+  test 'it calcs the new price with VAT field whenever input_vat, output_vat or price is changed' do
+    product = Product.first
+
+    #output
+    price_with_vat = product.price_with_vat
+    product.update output_vat: product.output_vat+1
+    assert_not_equal price_with_vat, product.price_with_vat
+
+    #input
+    price_with_vat = product.price_with_vat
+    product.update input_vat: product.input_vat+1
+    assert_not_equal price_with_vat, product.price_with_vat
+
+    #price
+    price_with_vat = product.price_with_vat
+    product.update price: product.price+10
+    assert_not_equal price_with_vat, product.price_with_vat
+  end
+
+  test 'it should calc the sum of all products with VAT' do
+    total = Product.all.inject(0) {|total,p| total += p.price * (1 + p.output_vat/100) - p.input_vat }.round(2)
+    assert_equal total, Product.prices_sum_with_vat.to_f
+    assert_equal total, Product.prices_sum_with_vat(Product.all).to_f
+  end
+
+  test 'it should get the cheapest product with VAT' do
+    assert_equal "apple", Product.cheapest_with_vat.name
+    assert_equal "apple", Product.all.cheapest_with_vat.name
+  end
+
+  test 'it should get the most expensive product with VAT' do
+    assert_equal "mango", Product.most_expensive_with_vat.name
+    assert_equal "mango", Product.all.most_expensive_with_vat.name
+  end
+
+
 end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -1,0 +1,15 @@
+require 'test/unit'
+require_relative '../config/environment'
+
+class Test::Unit::TestCase
+
+  def setup_database
+    ActiveRecord::Base.establish_connection(
+      :adapter => 'sqlite3',
+      :database => 'db/store_test.sqlite3'
+    )
+    ActiveRecord::Migration.verbose = true
+    ActiveRecord::Migrator.migrate File.dirname(__FILE__) + '/../db/migrate/'
+    Product.destroy_all
+  end
+end


### PR DESCRIPTION
@martincik, for this assignment I had to read a little bit about VAT I had some real user experience with that, but Brazil doesn't have this kind of tax. As I understood, it receives a fixed input VAT already calculated on prior trading cycles (which should be removed from total VAT) and an output VAT which is a percentage of the price.
I know it is calculated in a different way for each country / area, but I thought for this test we could deal specifically with the VAT calculation and its relation with the product.

My solution for it was to intercept the modification of price, input and output field and to update the price_with_vat field which caches the price with the calculated vat. This way, we would be able to order it, sum it etc without increasing code complexity and decreasing performance.